### PR TITLE
Restart refactor

### DIFF
--- a/lib/discord_status_bot/application.ex
+++ b/lib/discord_status_bot/application.ex
@@ -18,7 +18,7 @@ defmodule HGSDiscordBot.Application do
       options: [
         %{
           name: "game_id",
-          description: "The ID of the game server to restart",
+          description: "The id of the game server to restart",
           type: 3,
           required: true
         }

--- a/lib/discord_status_bot/consumer.ex
+++ b/lib/discord_status_bot/consumer.ex
@@ -16,103 +16,115 @@ defmodule HGSDiscordBot.Consumer do
         {:INTERACTION_CREATE,
          %Interaction{type: 2, data: %{name: "status"}, channel_id: chan, id: id, token: token},
          _ws}
-      ) do
-    if chan in @allowed_channels do
-      response_text =
-        @endpoint
-        |> HTTPoison.get()
-        |> parse_response()
-        |> format_servers()
-        # ensures it’s a string even if something slips through
-        |> to_string()
+      )
+      when chan in @allowed_channels do
+    response_text =
+      @endpoint
+      |> HTTPoison.get()
+      |> parse_response()
+      |> format_servers()
 
-      IO.inspect(response_text, label: "🔍 response_text")
-
-      Api.Interaction.create_response(id, token, %{
-        type: 4,
-        data: %{content: response_text}
-      })
-    else
-      # send an ephemeral “you can’t do that here” message
-      Api.Interaction.create_response(id, token, %{
-        type: 4,
-        data: %{
-          content: "❌ You can only run `/status` in designated channels.",
-          # 64 = ephemeral
-          flags: Bitwise.bsl(1, 6)
-        }
-      })
-    end
+    Api.Interaction.create_response(id, token, %{
+      type: 4,
+      data: %{content: response_text}
+    })
   end
 
   def handle_event(
         {:INTERACTION_CREATE,
+         %Interaction{type: 2, data: %{name: "status"}, id: id, token: token}, _ws}
+      ) do
+    Api.Interaction.create_response(id, token, %{
+      type: 4,
+      data: %{content: "You cannot use `/status` in this channel.", flags: Bitwise.bsl(1, 6)}
+    })
+  end
+
+  @impl true
+  def handle_event(
+        {:INTERACTION_CREATE,
          %Interaction{
            type: 2,
-           data: %{name: "restart", options: [%{name: "game_id", value: game_id}]},
-           channel_id: chan,
-           id: id,
-           guild_id: guild_id,
-           user: user,
-           token: token
-         }, _ws}
+           data: %{name: "restart"}
+         } = interaction, _ws}
       ) do
-    if chan in @allowed_channels and has_role?(guild_id, user.id, @allowed_role_ids) do
-      # body = %{game: game_id} |> Jason.encode!()
-      # headers = [{"Content-Type", "application/json"}]
-      endpoint = "#{@restart_endpoint_url}#{game_id}"
-
-      Api.Interaction.create_response(id, token, %{
-        type: 4,
-        data: %{content: "♻ Attempting to restart **#{Utilities.get(game_id)}** ♻"}
-      })
-
-      # send POST
-      result =
-        case HTTPoison.post(
-               endpoint,
-               "",
-               [
-                 {"Content-Type", "application/json"},
-                 {"Accept", "application/json"}
-               ],
-               recv_timeout: 60_000
-             ) do
-          {:ok, %HTTPoison.Response{status_code: 200}} ->
-            "🚀 **#{Utilities.get(game_id)}** restarted successfully. 🚀"
-
-          {:ok, %HTTPoison.Response{status_code: _}} ->
-            "⚠️ Failed to restart.  Did you use the correct `game_id`?"
-
-          {:error, %HTTPoison.Error{reason: reason}} ->
-            "❌ HTTP error: #{inspect(reason)}"
-        end
-
-      case Api.Message.create(chan, %{content: result}) do
-        {:ok, _message} ->
-          IO.puts("Successfully sent message to channel")
-
-        {:error, error} ->
-          IO.inspect(error, label: "Failed to send message")
-      end
-    else
-      Api.Interaction.create_response(id, token, %{
-        type: 4,
-        data: %{
-          content: """
-          ❌ You either do not have permissions to restart servers or are
-          trying to do so in an ineligible channel
-          """,
-          # 64 = ephemeral
-          flags: Bitwise.bsl(1, 6)
-        }
-      })
-    end
+    # Delegate to a specialized handler based on channel and roles
+    handle_restart(
+      interaction,
+      has_role?(fetch_member_roles(interaction.guild_id, interaction.user.id), @allowed_role_ids)
+    )
   end
+
+  #   Api.Interaction.create_response(id, token, %{
+  #     type: 4,
+  #     data: %{content: "♻ Attempting to restart **#{Utilities.get(game_id)}** ♻"}
+  #   })
+
+  #   # send POST
+  #   result =
+  #     case HTTPoison.post(
+  #            endpoint,
+  #            "",
+  #            [
+  #              {"Content-Type", "application/json"},
+  #              {"Accept", "application/json"}
+  #            ],
+  #            recv_timeout: 60_000
+  #          ) do
+  #       {:ok, %HTTPoison.Response{status_code: 200}} ->
+  #         "🚀 **#{Utilities.get(game_id)}** restarted successfully. 🚀"
+
+  #       {:ok, %HTTPoison.Response{status_code: _}} ->
+  #         "⚠️ Failed to restart.  Did you use the correct `game_id`?"
+
+  #       {:error, %HTTPoison.Error{reason: reason}} ->
+  #         "❌ HTTP error: #{inspect(reason)}"
+  #     end
+
+  #   Api.Message.create(chan, %{content: result})
+  # end
 
   def handle_event(_), do: :noop
 
+  defp handle_restart(interaction, true) do
+    endpoint = "#{@restart_endpoint_url}#{interaction.game_id}"
+
+    Api.Interaction.create_response(interaction.id, interaction.token, %{
+      type: 4,
+      data: %{content: "♻ Attempting to restart **#{Utilities.get(interaction.game_id)}** ♻"}
+    })
+
+    result =
+      case HTTPoison.post(
+             endpoint,
+             "",
+             [
+               {"Content-Type", "application/json"},
+               {"Accept", "application/json"}
+             ],
+             recv_timeout: 60_000
+           ) do
+        {:ok, %HTTPoison.Response{status_code: 200}} ->
+          "🚀 **#{Utilities.get(interaction.game_id)}** restarted successfully. 🚀"
+
+        {:ok, %HTTPoison.Response{status_code: _}} ->
+          "⚠️ Failed to restart.  Did you use the correct `game_id`?"
+
+        {:error, %HTTPoison.Error{reason: reason}} ->
+          "❌ HTTP error: #{inspect(reason)}"
+      end
+
+    Api.Message.create(interaction.channel, %{content: result})
+  end
+
   # --- helpers below ---
+
+  defp fetch_member_roles(guild_id, user_id) do
+    case Api.Guild.member(guild_id, user_id) do
+      {:ok, %Member{roles: roles}} -> {:ok, roles}
+      _error -> {:error, []}
+    end
+  end
 
   # Check if a member has a specific role (by role ID)
   def has_role?(guild_id, user_id, allowed_role_ids) do
@@ -123,6 +135,10 @@ defmodule HGSDiscordBot.Consumer do
       _error ->
         false
     end
+  end
+
+  def has_role?(user_roles, allowed_role_ids) do
+    Enum.any?(user_roles, fn role -> role in allowed_role_ids end)
   end
 
   defp parse_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}),


### PR DESCRIPTION
Refactored the pattern matching for restarting servers, which will now properly check for permission and the correct channel before attempting to send a restart.  This is a bit cleaner, although there is still work to do to separate some of the code into different modules. 